### PR TITLE
Add CFLAGS and friends to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CPPFLAGS := -DFORTIFY_SOURCE=2
 LDFLAGS := -static -Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now,--hash-style=gnu,-Bstatic
 
 multirun: multirun.c
-	$(CC) -c -o $@.o $(CFLAGS) $^
+	$(CC) -c -o $@.o $(CPPFLAGS) $(CFLAGS) $^
 	$(CC) -o $@ $(LDFLAGS) $@.o
 
 test: multirun

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,12 @@
-PREFIX = /usr
+PREFIX := /usr/local
+CC := gcc
+CFLAGS := -std=gnu11 -O3 -static -no-pie -pipe -fstack-protector-strong -fPIC -fno-plt -fomit-frame-pointer
+CPPFLAGS := -DFORTIFY_SOURCE=2
+LDFLAGS := -static -Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now,--hash-style=gnu,-Bstatic
 
 multirun: multirun.c
-	cc -std=gnu11 -o multirun multirun.c
+	$(CC) -c -o $@.o $(CFLAGS) $^
+	$(CC) -o $@ $(LDFLAGS) $@.o
 
 test: multirun
 	bats tests.bats
@@ -9,6 +14,7 @@ test: multirun
 .PHONY: clean
 clean:
 	-rm multirun
+	-rm multirun.o
 
 .PHONY: install
 install: multirun


### PR DESCRIPTION
- Add defaults for `CC` `CFLAGS`, `CPPFLAGS`, and `LDFLAGS`
- Set default `PREFIX` to `/usr/local`
- Compile and link in separate steps

This way downstream can add flags and change the prefix without patching the Makefile. Feel free to make any edits.